### PR TITLE
Add EntrepriseChannelVariables to OriginateOptions

### DIFF
--- a/NEventSocket.Examples/CommandLineTaskRunner.cs
+++ b/NEventSocket.Examples/CommandLineTaskRunner.cs
@@ -11,6 +11,8 @@ using Serilog.Events;
 
 namespace NEventSocket.Examples
 {
+    using NEventSocket.Examples.NetCore;
+
     public class CommandLineTaskRunner : IDisposable
     {
         private CancellationTokenSource cancellationTokenSource;

--- a/NEventSocket.Tests/Applications/Applications.cs
+++ b/NEventSocket.Tests/Applications/Applications.cs
@@ -41,13 +41,15 @@
                                    TimeoutSeconds = 20
                                };
 
+             options.EnterpriseChannelVariables.Add("fooE", "barE");
+             options.EnterpriseChannelVariables.Add("bazE", "widgetsE");
              options.ChannelVariables.Add("foo", "bar");
              options.ChannelVariables.Add("baz", "widgets");
 
              var toString = options.ToString();
 
              const string Expected =
-                 "{origination_uuid='985cea12-4e70-4c03-8a2c-2c4b4502bbbb',bypass_media='true',origination_caller_id_name='Test',origination_caller_id_number='12341234',execute_on_originate='start_dtmf',ignore_early_media='true',originate_retries='3',originate_retry_sleep_ms='4000',return_ring_ready='true',originate_timeout='20',hangup_after_bridge='false',foo='bar',baz='widgets'}";
+                 "<fooE='barE',bazE='widgetsE'>{origination_uuid='985cea12-4e70-4c03-8a2c-2c4b4502bbbb',bypass_media='true',origination_caller_id_name='Test',origination_caller_id_number='12341234',execute_on_originate='start_dtmf',ignore_early_media='true',originate_retries='3',originate_retry_sleep_ms='4000',return_ring_ready='true',originate_timeout='20',hangup_after_bridge='false',foo='bar',baz='widgets'}";
              Assert.Equal(Expected, toString);
          }
 

--- a/NEventSocket.Tests/Applications/OriginateTests.cs
+++ b/NEventSocket.Tests/Applications/OriginateTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace NEventSocket.Tests.Applications
 {
+    using System.Collections.Generic;
     using System.IO;
     using System.Runtime.Serialization.Formatters.Binary;
 
@@ -10,7 +11,7 @@
     public class OriginateTests
     {
         [Fact]
-        public void Can_format_originate_options()
+        public void can_format_originate_options()
         {
             var options = new OriginateOptions()
                               {
@@ -28,6 +29,31 @@
             Assert.Equal(
                 "{origination_caller_id_name='Dan',origination_caller_id_number='0123457890',execute_on_originate='my_app::my_arg',originate_retries='5',originate_retry_sleep_ms='200',return_ring_ready='true',originate_timeout='60',origination_uuid='83fe4f3d-b957-4b26-b6bf-3879d7e21972',ignore_early_media='true'}",
                 options.ToString());
+        }
+
+        [Fact]
+        public void can_set_enterprise_channel_variables()
+        {
+            var options = new OriginateOptions 
+                { 
+                    EnterpriseChannelVariables = new Dictionary<string, string>
+                    {
+                         {"e1" , "ev1"},
+                         {"e2" , "ev2"}
+                    }
+                }.ToString();
+            Assert.Contains("<e1='ev1',e2='ev2'>", options);
+        }
+
+        [Fact]
+        public void can_set_enterprise_channel_variables_and_channel_variables()
+        {
+            var options = new OriginateOptions
+                          {
+                              EnterpriseChannelVariables = new Dictionary<string, string> { { "e1", "ev1" }, { "e2", "ev2" } },
+                              ChannelVariables = new Dictionary<string, string> { { "c1", "cv1" }, { "c2", "cv2" } }
+                          }.ToString();
+            Assert.Contains("<e1='ev1',e2='ev2'>{c1='cv1',c2='cv2'}", options);
         }
 
         [Fact]

--- a/NEventSocket/FreeSwitch/OriginateOptions.cs
+++ b/NEventSocket/FreeSwitch/OriginateOptions.cs
@@ -10,6 +10,7 @@ namespace NEventSocket.FreeSwitch
     using System.Collections.Generic;
     using System.Linq;
     using System.Runtime.Serialization;
+    using System.Text;
 
     using NEventSocket.Util;
     using NEventSocket.Util.ObjectPooling;
@@ -32,6 +33,7 @@ namespace NEventSocket.FreeSwitch
         public OriginateOptions()
         {
             ChannelVariables = new Dictionary<string, string>();
+            EnterpriseChannelVariables = new Dictionary<string, string>();
         }
 
         /// <summary>
@@ -41,6 +43,8 @@ namespace NEventSocket.FreeSwitch
         {
             parameters =
                 (Dictionary<string, string>)info.GetValue("parameters", typeof(Dictionary<string, string>));
+            EnterpriseChannelVariables =
+                (Dictionary<string, string>)info.GetValue("EnterpriseChannelVariables", typeof(Dictionary<string, string>));
             ChannelVariables =
                 (Dictionary<string, string>)info.GetValue("ChannelVariables", typeof(Dictionary<string, string>));
         }
@@ -240,6 +244,11 @@ namespace NEventSocket.FreeSwitch
         public IDictionary<string, string> ChannelVariables { get; set; }
 
         /// <summary>
+        /// Container for any Enterprise Channel Variables to be set before executing the origination
+        /// </summary>
+        public IDictionary<string, string> EnterpriseChannelVariables { get; set; }
+
+        /// <summary>
         /// Implements the operator ==.
         /// </summary>
         public static bool operator ==(OriginateOptions left, OriginateOptions right)
@@ -262,6 +271,39 @@ namespace NEventSocket.FreeSwitch
         public override string ToString()
         {
             var sb = StringBuilderPool.Allocate();
+            AppendOriginateEnterpriseChannelVariablesString(sb);
+            AppendOriginateChannelVariablesString(sb);
+
+            return StringBuilderPool.ReturnAndFree(sb);
+        }
+
+        /// <summary>
+        /// Append enterprise channel variables to string builder
+        /// </summary>
+        private void AppendOriginateEnterpriseChannelVariablesString(StringBuilder sb)
+        {
+            if (!EnterpriseChannelVariables.Any())
+            {
+                return;
+            }
+
+            sb.Append("<");
+
+            sb.Append(EnterpriseChannelVariables.ToOriginateString());
+
+            if (sb.Length > 1)
+            {
+                sb.Remove(sb.Length - 1, 1);
+            }
+
+            sb.Append(">");
+        }
+
+        /// <summary>
+        /// Append channel variables to string builder
+        /// </summary>
+        private void AppendOriginateChannelVariablesString(StringBuilder sb)
+        {
             sb.Append("{");
 
             sb.Append(parameters.ToOriginateString());
@@ -273,8 +315,6 @@ namespace NEventSocket.FreeSwitch
             }
 
             sb.Append("}");
-
-            return StringBuilderPool.ReturnAndFree(sb);
         }
 
         /// <summary>
@@ -283,6 +323,7 @@ namespace NEventSocket.FreeSwitch
         public void GetObjectData(SerializationInfo info, StreamingContext context)
         {
             info.AddValue("parameters", parameters, typeof(Dictionary<string, string>));
+            info.AddValue("EnterpriseChannelVariables", EnterpriseChannelVariables, typeof(Dictionary<string, string>));
             info.AddValue("ChannelVariables", ChannelVariables, typeof(Dictionary<string, string>));
         }
 
@@ -310,13 +351,13 @@ namespace NEventSocket.FreeSwitch
         {
             unchecked
             {
-                return ((ChannelVariables != null ? ChannelVariables.GetHashCode() : 0) * 397) ^ (parameters != null ? parameters.GetHashCode() : 0);
+                return ((EnterpriseChannelVariables != null ? EnterpriseChannelVariables.GetHashCode() : 0) * 531) ^ ((ChannelVariables != null ? ChannelVariables.GetHashCode() : 0) * 397) ^ (parameters != null ? parameters.GetHashCode() : 0);
             }
         }
 
         protected bool Equals(OriginateOptions other)
         {
-            return ChannelVariables.SequenceEqual(other.ChannelVariables) && parameters.SequenceEqual(other.parameters);
+            return EnterpriseChannelVariables.SequenceEqual(other.EnterpriseChannelVariables) && ChannelVariables.SequenceEqual(other.ChannelVariables) && parameters.SequenceEqual(other.parameters);
         }
     }
 }

--- a/NEventSocket/NEventSocket.csproj
+++ b/NEventSocket/NEventSocket.csproj
@@ -7,7 +7,7 @@
     <Company>iamkinetic</Company>
     <Product>NEventSocket.DotNetCore</Product>
     <Description>.Net Core port of NEventSocket</Description>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <RepositoryUrl>https://github.com/iamkinetic/NEventSocket</RepositoryUrl>
     <PackageTags>FreeSwitch NEventSocket DotNetCore</PackageTags>
     <PackageReleaseNotes>Initial beta version.</PackageReleaseNotes>


### PR DESCRIPTION
This is to add entreprise channel variables options to originate command. Example : originate <continue_on_fail=true>