### PR TITLE
Originate should not set UUID automatically.

### DIFF
--- a/NEventSocket/FreeSwitch/OriginateOptions.cs
+++ b/NEventSocket/FreeSwitch/OriginateOptions.cs
@@ -304,6 +304,11 @@ namespace NEventSocket.FreeSwitch
         /// </summary>
         private void AppendOriginateChannelVariablesString(StringBuilder sb)
         {
+            if (!ChannelVariables.Any())
+            {
+                return;
+            }
+
             sb.Append("{");
 
             sb.Append(parameters.ToOriginateString());


### PR DESCRIPTION
Also quick fix to remove nested '}'  when there is no ChannelVariables.