### PR TITLE
Parse messages and events based on byte arrays instead of strings

### DIFF
--- a/NEventSocket.Tests/TestSupport/TestMessages.cs
+++ b/NEventSocket.Tests/TestSupport/TestMessages.cs
@@ -278,6 +278,155 @@ Content-Length: 67
 Disconnected, goodbye.
 See you at ClueCon! http://www.cluecon.com/";
 
+        public const string DetectedSpeech = @"Content-Length: 2471
+Content-Type: text/event-plain
+
+Event-Name: DETECTED_SPEECH
+Core-UUID: ec530c4e-484d-473e-9bd0-073863f752eb
+FreeSWITCH-Hostname: ser
+FreeSWITCH-Switchname: ser
+FreeSWITCH-IPv4: 192.168.1.104
+FreeSWITCH-IPv6: %3A%3A1
+Event-Date-Local: 2021-06-28%2023%3A20%3A38
+Event-Date-GMT: Mon,%2028%20Jun%202021%2021%3A20%3A38%20GMT
+Event-Date-Timestamp: 1624915238513391
+Event-Calling-File: switch_ivr_async.c
+Event-Calling-Function: speech_thread
+Event-Calling-Line-Number: 4947
+Event-Sequence: 251969
+Speech-Type: detected-speech
+ASR-Completion-Cause: 0
+Channel-State: CS_EXECUTE
+Channel-Call-State: ACTIVE
+Channel-State-Number: 4
+Channel-Name: sofia/internal/%2B491734064561%40172.16.50.128
+Unique-ID: f5228692-9715-4b6f-b54b-9e35be1a7335
+Call-Direction: inbound
+Presence-Call-Direction: inbound
+Channel-HIT-Dialplan: true
+Channel-Presence-ID: %2B491734064561%40172.16.50.128
+Channel-Call-UUID: f5228692-9715-4b6f-b54b-9e35be1a7335
+Answer-State: answered
+Channel-Read-Codec-Name: G722
+Channel-Read-Codec-Rate: 16000
+Channel-Read-Codec-Bit-Rate: 64000
+Channel-Write-Codec-Name: G722
+Channel-Write-Codec-Rate: 16000
+Channel-Write-Codec-Bit-Rate: 64000
+Caller-Direction: inbound
+Caller-Logical-Direction: inbound
+Caller-Username: %2B491734000000
+Caller-Dialplan: XML
+Caller-Caller-ID-Name: %2B491734000000
+Caller-Caller-ID-Number: %2B491734000000
+Caller-Orig-Caller-ID-Name: %2B491734000000
+Caller-Orig-Caller-ID-Number: %2B491734000000
+Caller-Network-Addr: 10.1.10.100
+Caller-ANI: %2B491734000000
+Caller-Destination-Number: 493000000000000
+Caller-Unique-ID: f5228692-9715-4b6f-b54b-9e35be1a7335
+Caller-Source: mod_sofia
+Caller-Context: public
+Caller-Channel-Name: sofia/internal/%2B491734064561%40172.16.50.128
+Caller-Profile-Index: 1
+Caller-Profile-Created-Time: 1624915212053386
+Caller-Channel-Created-Time: 1624915212053386
+Caller-Channel-Answered-Time: 1624915222293356
+Caller-Channel-Progress-Time: 0
+Caller-Channel-Progress-Media-Time: 1624915216013390
+Caller-Channel-Hangup-Time: 0
+Caller-Channel-Transfer-Time: 0
+Caller-Channel-Resurrect-Time: 0
+Caller-Channel-Bridged-Time: 0
+Caller-Channel-Last-Hold: 0
+Caller-Channel-Hold-Accum: 0
+Caller-Screen-Bit: true
+Caller-Privacy-Hide-Name: false
+Caller-Privacy-Hide-Number: false
+Content-Length: 261
+
+<?xml version=""1.0""?>
+<result>
+  <interpretation grammar=""builtin:speech/transcribe"" confidence=""91"">
+    <instance>Verlängerung Störung Bestätigung</instance>
+    <input mode=""speech"">Verlängerung Störung Bestätigung</input>
+  </interpretation>
+</result>";
+
+        public const string DetectedSpeechEnglish = @"Content-Length: 2465
+Content-Type: text/event-plain
+
+Event-Name: DETECTED_SPEECH
+Core-UUID: ec530c4e-484d-473e-9bd0-073863f752eb
+FreeSWITCH-Hostname: ser
+FreeSWITCH-Switchname: ser
+FreeSWITCH-IPv4: 192.168.1.104
+FreeSWITCH-IPv6: %3A%3A1
+Event-Date-Local: 2021-06-28%2023%3A20%3A38
+Event-Date-GMT: Mon,%2028%20Jun%202021%2021%3A20%3A38%20GMT
+Event-Date-Timestamp: 1624915238513391
+Event-Calling-File: switch_ivr_async.c
+Event-Calling-Function: speech_thread
+Event-Calling-Line-Number: 4947
+Event-Sequence: 251969
+Speech-Type: detected-speech
+ASR-Completion-Cause: 0
+Channel-State: CS_EXECUTE
+Channel-Call-State: ACTIVE
+Channel-State-Number: 4
+Channel-Name: sofia/internal/%2B491734064561%40172.16.50.128
+Unique-ID: f5228692-9715-4b6f-b54b-9e35be1a7335
+Call-Direction: inbound
+Presence-Call-Direction: inbound
+Channel-HIT-Dialplan: true
+Channel-Presence-ID: %2B491734064561%40172.16.50.128
+Channel-Call-UUID: f5228692-9715-4b6f-b54b-9e35be1a7335
+Answer-State: answered
+Channel-Read-Codec-Name: G722
+Channel-Read-Codec-Rate: 16000
+Channel-Read-Codec-Bit-Rate: 64000
+Channel-Write-Codec-Name: G722
+Channel-Write-Codec-Rate: 16000
+Channel-Write-Codec-Bit-Rate: 64000
+Caller-Direction: inbound
+Caller-Logical-Direction: inbound
+Caller-Username: %2B491734000000
+Caller-Dialplan: XML
+Caller-Caller-ID-Name: %2B491734000000
+Caller-Caller-ID-Number: %2B491734000000
+Caller-Orig-Caller-ID-Name: %2B491734000000
+Caller-Orig-Caller-ID-Number: %2B491734000000
+Caller-Network-Addr: 10.1.10.100
+Caller-ANI: %2B491734000000
+Caller-Destination-Number: 493000000000000
+Caller-Unique-ID: f5228692-9715-4b6f-b54b-9e35be1a7335
+Caller-Source: mod_sofia
+Caller-Context: public
+Caller-Channel-Name: sofia/internal/%2B491734064561%40172.16.50.128
+Caller-Profile-Index: 1
+Caller-Profile-Created-Time: 1624915212053386
+Caller-Channel-Created-Time: 1624915212053386
+Caller-Channel-Answered-Time: 1624915222293356
+Caller-Channel-Progress-Time: 0
+Caller-Channel-Progress-Media-Time: 1624915216013390
+Caller-Channel-Hangup-Time: 0
+Caller-Channel-Transfer-Time: 0
+Caller-Channel-Resurrect-Time: 0
+Caller-Channel-Bridged-Time: 0
+Caller-Channel-Last-Hold: 0
+Caller-Channel-Hold-Accum: 0
+Caller-Screen-Bit: true
+Caller-Privacy-Hide-Name: false
+Caller-Privacy-Hide-Number: false
+Content-Length: 255
+
+<?xml version=""1.0""?>
+<result>
+  <interpretation grammar=""builtin:speech/transcribe"" confidence=""91"">
+    <instance>Extensions Problems Confirmation</instance>
+    <input mode=""speech"">Extensions Problems Confirmation</input>
+  </interpretation>
+</result>";
 
         public const string PlaybackComplete = @"Content-Length: 7209
 Content-Type: text/event-plain

--- a/NEventSocket/FreeSwitch/BasicMessage.cs
+++ b/NEventSocket/FreeSwitch/BasicMessage.cs
@@ -9,7 +9,7 @@ namespace NEventSocket.FreeSwitch
     using System;
     using System.Collections.Generic;
     using System.Linq;
-
+    using System.Text;
     using NEventSocket.Util;
     using NEventSocket.Util.ObjectPooling;
 
@@ -25,10 +25,11 @@ namespace NEventSocket.FreeSwitch
             Headers = new Dictionary<string, string>(headers, StringComparer.OrdinalIgnoreCase);
         }
 
-        internal BasicMessage(IDictionary<string, string> headers, string body)
+        internal BasicMessage(IDictionary<string, string> headers, byte[] bodyBytes)
         {
             Headers = new Dictionary<string, string>(headers, StringComparer.OrdinalIgnoreCase);
-            BodyText = body;
+            BodyText = Encoding.UTF8.GetString(bodyBytes);
+            BodyBytes = bodyBytes;
         }
 
         /// <summary>
@@ -47,6 +48,8 @@ namespace NEventSocket.FreeSwitch
         /// Gets any body text, if any, contained in the Message.
         /// </summary>
         public string BodyText { get; protected set; }
+
+        public byte[] BodyBytes { get; protected set; }
 
         /// <summary>
         /// Gets the Content Type header.

--- a/NEventSocket/NEventSocket.csproj
+++ b/NEventSocket/NEventSocket.csproj
@@ -7,7 +7,7 @@
     <Company>iamkinetic</Company>
     <Product>NEventSocket.DotNetCore</Product>
     <Description>.Net Core port of NEventSocket</Description>
-    <Version>2.0.2</Version>
+    <Version>2.0.3</Version>
     <RepositoryUrl>https://github.com/iamkinetic/NEventSocket</RepositoryUrl>
     <PackageTags>FreeSwitch NEventSocket DotNetCore</PackageTags>
     <PackageReleaseNotes>- .Net Standard 2.0 support.

--- a/NEventSocket/Sockets/EventSocket.cs
+++ b/NEventSocket/Sockets/EventSocket.cs
@@ -50,8 +50,8 @@ namespace NEventSocket.Sockets
             ResponseTimeOut = responseTimeOut ?? TimeSpan.FromSeconds(5);
 
             messages =
-                Receiver.SelectMany(x => Encoding.UTF8.GetString(x))
-                    .AggregateUntil(() => new Parser(), (builder, ch) => builder.Append(ch), builder => builder.Completed)
+                Receiver.SelectMany(x => x)
+                    .AggregateUntil(() => new Parser(), (builder, b) => builder.Append(b), builder => builder.Completed)
                     .Select(builder => builder.ExtractMessage())
                     .Do(
                         x => Log.LogTrace("Messages Received [{0}].".Fmt(x.ContentType)),

--- a/NEventSocket/Sockets/Parser.cs
+++ b/NEventSocket/Sockets/Parser.cs
@@ -8,27 +8,28 @@ namespace NEventSocket.Sockets
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
+    using System.IO;
     using System.Text;
-
     using NEventSocket.FreeSwitch;
     using NEventSocket.Util;
-    using NEventSocket.Util.ObjectPooling;
 
     /// <summary>
     /// A parser for converting a stream of strings or chars into a stream of <seealso cref="BasicMessage"/>s from FreeSwitch.
     /// </summary>
     public class Parser : IDisposable
     {
-        private StringBuilder buffer = StringBuilderPool.Allocate();
-
-        private char previous;
+        private byte previous;
 
         private int? contentLength;
 
         private IDictionary<string, string> headers;
 
+        private MemoryStream headerBytes = new MemoryStream();
+        private MemoryStream bodyBytes;
+
         private readonly InterlockedBoolean disposed = new InterlockedBoolean();
 
+        private const byte headerEndDelimiter = (byte)'\n';
         ~Parser()
         {
             Dispose(false);
@@ -45,26 +46,25 @@ namespace NEventSocket.Sockets
         public bool HasBody => contentLength.HasValue && contentLength > 0;
 
         /// <summary>
-        /// Appends the given <see cref="char"/> to the message.
+        /// Appends the given <see cref="byte"/> to the message.
         /// </summary>
-        /// <param name="next">The next <see cref="char"/> of the message.</param>
+        /// <param name="next">The next <see cref="byte"/> of the message.</param>
         /// <returns>The same instance of the <see cref="Parser"/>.</returns>
-        public Parser Append(char next)
+        public Parser Append(byte next)
         {
             if (Completed)
             {
                 return new Parser().Append(next);
             }
 
-            buffer.Append(next);
-
             if (!HasBody)
             {
+                headerBytes.WriteByte(next);
                 // we're parsing the headers
-                if (previous == '\n' && next == '\n')
+                if (previous == headerEndDelimiter && next == headerEndDelimiter)
                 {
                     // \n\n denotes the end of the Headers
-                    var headerString = buffer.ToString();
+                    var headerString = Encoding.UTF8.GetString(headerBytes.ToArray());
 
                     headers = headerString.ParseKeyValuePairs(": ");
 
@@ -79,10 +79,7 @@ namespace NEventSocket.Sockets
                         else
                         {
                             // start parsing the body content
-                            buffer.Clear();
-
-                            // allocate the buffer up front given that we now know the expected size
-                            buffer.EnsureCapacity(contentLength.Value);
+                            bodyBytes = new MemoryStream(contentLength.Value);
                         }
                     }
                     else
@@ -98,8 +95,11 @@ namespace NEventSocket.Sockets
             }
             else
             {
+                Debug.Assert(bodyBytes != null);
+                bodyBytes.WriteByte(next);
                 // if we've read the Content-Length amount of bytes then we're done
-                Completed = buffer.Length == contentLength.GetValueOrDefault() || contentLength == 0;
+                Debug.Assert(contentLength > 0);
+                Completed = bodyBytes.Length == contentLength.GetValueOrDefault();
             }
 
             return this;
@@ -108,11 +108,11 @@ namespace NEventSocket.Sockets
         /// <summary>
         /// Appends the provided string to the internal buffer.
         /// </summary>
-        public Parser Append(string next)
+        public Parser Append(byte[] next)
         {
             var parser = this;
 
-            foreach (var c in next)
+            foreach (var b in next)
             {
                 parser = parser.Append(next);
             }
@@ -141,17 +141,17 @@ namespace NEventSocket.Sockets
 
                 if (HasBody)
                 {
-                    errorMessage += "expected a body with length {0}, got {1} instead.".Fmt(contentLength, buffer.Length);
+                    errorMessage += "expected a body with length {0}, got {1} instead.".Fmt(contentLength, bodyBytes.Length);
                 }
 
                 throw new InvalidOperationException(errorMessage);
             }
 
-            var result = HasBody ? new BasicMessage(headers, buffer.ToString()) : new BasicMessage(headers);
+            var result = HasBody ? new BasicMessage(headers, bodyBytes.ToArray()) : new BasicMessage(headers);
 
             if (HasBody)
             {
-                Debug.Assert(result.BodyText.Length == result.ContentLength);
+                Debug.Assert(bodyBytes.Length == result.ContentLength);
             }
 
             Dispose();
@@ -168,11 +168,7 @@ namespace NEventSocket.Sockets
         {
             if (disposed != null && !disposed.EnsureCalledOnce())
             {
-                if (buffer != null)
-                {
-                    StringBuilderPool.Free(buffer);
-                    buffer = null;
-                }
+                bodyBytes = null;
             }
         }
     }


### PR DESCRIPTION
Parse responses encoded in multibyte character sets (e.g. UTF-8) correctly by applying the content length given in the response to the length of the raw byte array and not the encoded string. The length of the string and the length of the byte array are not necessarily equivalent.