### PR TITLE
Avoid "index out of range" exceptions with empty error responses

### DIFF
--- a/NEventSocket.Tests/Sockets/MessageParsingTests.cs
+++ b/NEventSocket.Tests/Sockets/MessageParsingTests.cs
@@ -176,6 +176,27 @@ namespace NEventSocket.Tests.Sockets
         }
 
         [Fact]
+        public void it_should_parse_empty_string_when_empty_Command_Reply_ERR()
+        {
+            var parser = new Parser();
+            var rawInput = "Content-Type: command/reply\nReply-Text: -ERR\n\n";
+
+            foreach (char c in rawInput)
+            {
+                parser.Append(c);
+            }
+
+            Assert.True(parser.Completed);
+
+            var reply = new CommandReply(parser.ExtractMessage());
+            Assert.NotNull(reply);
+            Assert.False(reply.Success);
+            Assert.Equal(string.Empty, reply.ErrorMessage);
+
+            Console.WriteLine(reply);
+        }
+
+        [Fact]
         public void it_should_parse_Api_Response_OK()
         {
             var parser = new Parser();
@@ -212,6 +233,26 @@ namespace NEventSocket.Tests.Sockets
             Assert.NotNull(response);
             Assert.False(response.Success);
             Assert.Equal("Error", response.ErrorMessage);
+
+            Console.WriteLine(response);
+        }
+
+        [Fact]
+        public void it_should_parse_empty_string_when_empty_Api_Response_ERR()
+        {
+            var parser = new Parser();
+            var rawInput = "Content-Type: api/response\nContent-Length: 4\n\n-ERR";
+
+            foreach (char c in rawInput)
+            {
+                parser.Append(c);
+            }
+
+            Assert.True(parser.Completed);
+
+            var response = new ApiResponse(parser.ExtractMessage());
+            Assert.False(response.Success);
+            Assert.Equal(string.Empty, response.ErrorMessage);
 
             Console.WriteLine(response);
         }

--- a/NEventSocket/FreeSwitch/ApiResponse.cs
+++ b/NEventSocket/FreeSwitch/ApiResponse.cs
@@ -51,7 +51,7 @@ namespace NEventSocket.FreeSwitch
         {
             get
             {
-                return BodyText != null && BodyText.StartsWith("-ERR")
+                return BodyText != null && BodyText.StartsWith("-ERR ")
                            ? BodyText.Substring(5, BodyText.Length - 5)
                            : string.Empty;
             }

--- a/NEventSocket/FreeSwitch/CommandReply.cs
+++ b/NEventSocket/FreeSwitch/CommandReply.cs
@@ -56,7 +56,7 @@ namespace NEventSocket.FreeSwitch
         {
             get
             {
-                return ReplyText != null && ReplyText.StartsWith("-ERR")
+                return ReplyText != null && ReplyText.StartsWith("-ERR ")
                            ? ReplyText.Substring(5, ReplyText.Length - 5)
                            : string.Empty;
             }


### PR DESCRIPTION
This pull request addresses the problem described in #25.