### PR TITLE
Handles channel and enterprise variables concurrently

### DIFF
--- a/NEventSocket.Tests/Applications/Applications.cs
+++ b/NEventSocket.Tests/Applications/Applications.cs
@@ -50,7 +50,7 @@
              var toString = options.ToString();
 
              const string Expected =
-                 "<fooE='barE',bazE='widgetsE'>{origination_uuid='985cea12-4e70-4c03-8a2c-2c4b4502bbbb',bypass_media='true',origination_caller_id_name='Test',origination_caller_id_number='12341234',execute_on_originate='start_dtmf',ignore_early_media='true',originate_retries='3',originate_retry_sleep_ms='4000',return_ring_ready='true',originate_timeout='20',hangup_after_bridge='false',foo='bar',baz='widgets'}";
+                 "{origination_uuid='985cea12-4e70-4c03-8a2c-2c4b4502bbbb',bypass_media='true',origination_caller_id_name='Test',origination_caller_id_number='12341234',execute_on_originate='start_dtmf',ignore_early_media='true',originate_retries='3',originate_retry_sleep_ms='4000',return_ring_ready='true',originate_timeout='20',fooE='barE',bazE='widgetsE',hangup_after_bridge='false',foo='bar',baz='widgets'}";
              Assert.That(toString, Is.EqualTo(Expected));
          }
 

--- a/NEventSocket.Tests/Applications/OriginateTests.cs
+++ b/NEventSocket.Tests/Applications/OriginateTests.cs
@@ -41,7 +41,7 @@
                          {"e2" , "ev2"}
                     }
                 }.ToString();
-            Assert.That(options, Does.Contain("<e1='ev1',e2='ev2'>"));
+            Assert.That(options, Does.Contain("{e1='ev1',e2='ev2'}"));
         }
 
         [Test]
@@ -52,7 +52,7 @@
                               EnterpriseChannelVariables = new Dictionary<string, string> { { "e1", "ev1" }, { "e2", "ev2" } },
                               ChannelVariables = new Dictionary<string, string> { { "c1", "cv1" }, { "c2", "cv2" } }
                           }.ToString();
-            Assert.That(options, Does.Contain("<e1='ev1',e2='ev2'>{c1='cv1',c2='cv2'}"));
+            Assert.That(options, Does.Contain("{e1='ev1',e2='ev2',c1='cv1',c2='cv2'}"));
         }
 
         [Test]

--- a/NEventSocket/FreeSwitch/OriginateOptions.cs
+++ b/NEventSocket/FreeSwitch/OriginateOptions.cs
@@ -287,7 +287,7 @@ namespace NEventSocket.FreeSwitch
                 return;
             }
 
-            sb.Append("<");
+            sb.Append("{");
 
             sb.Append(EnterpriseChannelVariables.ToOriginateString());
 
@@ -296,7 +296,7 @@ namespace NEventSocket.FreeSwitch
                 sb.Remove(sb.Length - 1, 1);
             }
 
-            sb.Append(">");
+            sb.Append("}");
         }
 
         /// <summary>

--- a/NEventSocket/FreeSwitch/OriginateOptions.cs
+++ b/NEventSocket/FreeSwitch/OriginateOptions.cs
@@ -271,32 +271,9 @@ namespace NEventSocket.FreeSwitch
         public override string ToString()
         {
             var sb = StringBuilderPool.Allocate();
-            AppendOriginateEnterpriseChannelVariablesString(sb);
             AppendOriginateChannelVariablesString(sb);
 
             return StringBuilderPool.ReturnAndFree(sb);
-        }
-
-        /// <summary>
-        /// Append enterprise channel variables to string builder
-        /// </summary>
-        private void AppendOriginateEnterpriseChannelVariablesString(StringBuilder sb)
-        {
-            if (!EnterpriseChannelVariables.Any())
-            {
-                return;
-            }
-
-            sb.Append("{");
-
-            sb.Append(EnterpriseChannelVariables.ToOriginateString());
-
-            if (sb.Length > 1)
-            {
-                sb.Remove(sb.Length - 1, 1);
-            }
-
-            sb.Append("}");
         }
 
         /// <summary>
@@ -304,7 +281,7 @@ namespace NEventSocket.FreeSwitch
         /// </summary>
         private void AppendOriginateChannelVariablesString(StringBuilder sb)
         {
-            if (!ChannelVariables.Any() && !parameters.Any())
+            if (!parameters.Any() && !EnterpriseChannelVariables.Any() && !ChannelVariables.Any())
             {
                 return;
             }
@@ -312,6 +289,7 @@ namespace NEventSocket.FreeSwitch
             sb.Append("{");
 
             sb.Append(parameters.ToOriginateString());
+            sb.Append(EnterpriseChannelVariables.ToOriginateString()); //ici, je crois que pour une entreprise variable il faurait ajouter le caractere $ dans la valeur pour dire que c'est un entreprise variable
             sb.Append(ChannelVariables.ToOriginateString());
 
             if (sb.Length > 1)


### PR DESCRIPTION
Ensures proper handling of both channel and enterprise variables within originate options.

- Modifies the originate string generation to correctly include both types of variables.
- Addresses a scenario where both channel and enterprise variables are present simultaneously.
- Enterprise variables are now enclosed in curly braces `{}` instead of angle brackets `<>`.

SOFT-2203